### PR TITLE
bugs: fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.2.0 2025-09-27
+
+* 新增“解析全文”选项，可将 arXiv HTML 渲染内容转换为 Markdown 并插入思源笔记。
+* 当 HTML 渲染不可用时，新增对 LaTeX 源码压缩包的兜底解析能力。
+* 将作者、参考文献、致谢等信息压缩为代码块展示，并优化插入对话框体验。
+* Added an optional "Parse full text" toggle to convert arXiv HTML renderings into Markdown inside SiYuan.
+* Added a LaTeX source archive fallback when HTML rendering is unavailable.
+* Compressed author, reference, and acknowledgement sections into compact code blocks and refined the insert dialog UX.
+
 ## v0.1.0 2025-09-27
 
 * 实现在思源笔记中根据 arxiv 链接自动爬取 pdf 文件到本地资源目录

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Having issues? --> https://github.com/Jasaxion/siyuan-arxiv-paper-download/issue
 - Adds a `/` command named **Insert arXiv paper**.
 - Accepts `https://arxiv.org/abs/...`, `https://arxiv.org/pdf/...`, or raw identifiers such as `2509.17567`.
 - Downloads the PDF, stores it in `assets/`, and inserts a Markdown link using the paper title as the filename.
+- Optionally parses the paper into Markdown via arXiv's HTML rendering (with a LaTeX archive fallback) when **Parse full text** is enabled.
 - Skips re-downloading when the titled PDF already exists in `assets/` and simply reuses it.
 - Can be used in conjunction with the additional plugin PaperLess to achieve global management of personal academic paper documents: [PaperLess](https://github.com/Jasaxion/siyuan-paperless)
 
@@ -22,8 +23,8 @@ Having issues? --> https://github.com/Jasaxion/siyuan-arxiv-paper-download/issue
 
 1. Open any document in SiYuan and type `/` to open the slash menu.
 2. Select **Insert arXiv paper**.
-3. Paste an arXiv link or identifier in the dialog and confirm.
-4. The PDF is saved under `assets/` and a link like `[paper-title.pdf](assets/paper-title.pdf)` is inserted.
+3. Paste an arXiv link or identifier in the dialog, optionally enable **Parse full text**, and confirm.
+4. Either the parsed Markdown content is inserted directly, or the PDF is saved under `assets/` and a link like `[paper-title.pdf](assets/paper-title.pdf)` is added.
 
 ## Development
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -13,6 +13,7 @@
 - 在输入 `/` 时新增 **插入 arXiv 论文** 菜单项。
 - 支持 `https://arxiv.org/abs/...`、`https://arxiv.org/pdf/...` 以及 `2509.17567` 等编号格式。
 - 自动获取论文标题，下载 PDF 到 `assets/` 目录，并以标题命名。
+- 可选开启“解析全文”，优先使用 arXiv HTML 渲染转换为 Markdown（若不可用则回退解析 LaTeX 压缩包）。
 - 如果 `assets/` 中已存在同名 PDF，则直接复用，避免重复下载。
 - 在文档中插入 `[论文标题.pdf](assets/论文标题.pdf)` 格式的链接。
 - 可以配合另外的插件 PaperLess 实现全局的个人论文文档库管理: [PaperLess](https://github.com/Jasaxion/siyuan-paperless)
@@ -21,8 +22,8 @@
 
 1. 在任意文档中输入 `/` 打开菜单。
 2. 选择 **插入 arXiv 论文**。
-3. 输入或粘贴 arXiv 链接 / 编号并确认。
-4. 插件会自动下载并插入链接。
+3. 输入或粘贴 arXiv 链接 / 编号，视需求勾选“解析全文”，然后确认。
+4. 若解析成功会直接插入 Markdown 内容；否则下载 PDF 并插入对应链接。
 
 ## 开发
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siyuan-arxiv-paper-download",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "SiYuan plugin for inserting and downloading arXiv papers.",
   "main": ".src/index.js",
   "scripts": {
@@ -32,5 +32,10 @@
     "webpack-cli": "^5.0.2",
     "zip-webpack-plugin": "^4.0.1",
     "globals": "^16.3.0"
+  },
+  "dependencies": {
+    "fflate": "^0.8.1",
+    "js-untar": "^2.0.0",
+    "turndown": "^7.2.0"
   }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "siyuan-arxiv-paper-download",
   "author": "Jasaxion(BaiBo)",
   "url": "https://github.com/Jasaxion/siyuan-arxiv-paper-download",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "minAppVersion": "3.3.0",
   "backends": "all",
   "frontends": "all",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,16 @@ settings:
 importers:
 
   .:
+    dependencies:
+      fflate:
+        specifier: ^0.8.1
+        version: 0.8.2
+      js-untar:
+        specifier: ^2.0.0
+        version: 2.0.0
+      turndown:
+        specifier: ^7.2.0
+        version: 7.2.1
     devDependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: 8.40.0
@@ -270,6 +280,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mixmark-io/domino@2.2.0':
+    resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -798,6 +811,9 @@ packages:
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -932,6 +948,9 @@ packages:
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
+
+  js-untar@2.0.0:
+    resolution: {integrity: sha512-7CsDLrYQMbLxDt2zl9uKaPZSdmJMvGGQ7wo9hoB3J+z/VcO2w63bXFgHVnjF1+S9wD3zAu8FBVj7EYWjTQ3Z7g==}
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -1319,6 +1338,9 @@ packages:
   tslib@2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
 
+  turndown@7.2.1:
+    resolution: {integrity: sha512-7YiPJw6rLClQL3oUKN3KgMaXeJJ2lAyZItclgKDurqnH61so4k4IH/qwmMva0zpuJc/FhRExBBnk7EbeFANlgQ==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -1556,6 +1578,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mixmark-io/domino@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -2138,6 +2162,8 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fflate@0.8.2: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -2252,6 +2278,8 @@ snapshots:
       '@types/node': 24.5.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
+
+  js-untar@2.0.0: {}
 
   js-yaml@4.1.0:
     dependencies:
@@ -2565,6 +2593,10 @@ snapshots:
       typescript: 4.8.4
 
   tslib@2.4.0: {}
+
+  turndown@7.2.1:
+    dependencies:
+      '@mixmark-io/domino': 2.2.0
 
   type-check@0.4.0:
     dependencies:

--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -17,5 +17,16 @@
   "errorNotFound": "The specified arXiv paper was not found.",
   "errorMissingTitle": "The paper title could not be determined.",
   "errorDownloadPdf": "Failed to download the PDF file.",
-  "errorUploadPdf": "Failed to upload the PDF to SiYuan."
+  "errorUploadPdf": "Failed to upload the PDF to SiYuan.",
+  "parseFullTextLabel": "Parse full text",
+  "successParsedMessage": "Inserted parsed content for ${title}",
+  "statusFetchingHtml": "Fetching HTML rendering...",
+  "statusConvertingHtml": "Converting HTML to Markdown...",
+  "statusFallbackLatex": "Falling back to LaTeX archive...",
+  "errorParseFullTextFailed": "Failed to parse full text.",
+  "errorFetchHtml": "Failed to fetch HTML rendering from arXiv.",
+  "labelAuthors": "Authors",
+  "labelReferences": "References",
+  "labelAcknowledgements": "Acknowledgements",
+  "labelFigurePlaceholder": "Figure"
 }

--- a/src/i18n/zh_CN.json
+++ b/src/i18n/zh_CN.json
@@ -17,5 +17,16 @@
   "errorNotFound": "未找到对应的 arXiv 论文。",
   "errorMissingTitle": "无法获取论文标题。",
   "errorDownloadPdf": "下载 PDF 文件失败。",
-  "errorUploadPdf": "上传 PDF 到思源失败。"
+  "errorUploadPdf": "上传 PDF 到思源失败。",
+  "parseFullTextLabel": "解析全文",
+  "successParsedMessage": "已插入 ${title} 的解析内容",
+  "statusFetchingHtml": "正在获取 HTML 渲染...",
+  "statusConvertingHtml": "正在转换为 Markdown...",
+  "statusFallbackLatex": "尝试使用 LaTeX 压缩包...",
+  "errorParseFullTextFailed": "解析全文失败。",
+  "errorFetchHtml": "获取 arXiv HTML 渲染失败。",
+  "labelAuthors": "作者",
+  "labelReferences": "参考文献",
+  "labelAcknowledgements": "致谢",
+  "labelFigurePlaceholder": "图"
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -12,6 +12,18 @@
     width: 100%;
   }
 
+  &__checkbox {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: var(--b3-font-size);
+    color: var(--b3-theme-on-background);
+  }
+
+  &__checkbox .b3-switch {
+    margin-right: 8px;
+  }
+
   &__status {
     min-height: 20px;
     font-size: var(--b3-font-size-small);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
 import {Dialog, Plugin, Protyle, showMessage, getFrontend} from "siyuan";
+import TurndownService from "turndown";
+import {gunzipSync} from "fflate";
+import untar from "js-untar";
 import "./index.scss";
 
 const ASSETS_DIR = "/assets/";
@@ -20,6 +23,21 @@ interface ReadDirResponse {
         name: string;
         isDir: boolean;
     }>;
+}
+
+interface ArxivMetadata {
+    title: string;
+    pdfUrl: string;
+    canonicalId: string;
+    versionedId: string;
+    authors: string[];
+    summary?: string;
+}
+
+interface UntarEntry {
+    name: string;
+    buffer: ArrayBuffer;
+    type?: string;
 }
 
 export default class ArxivPaperPlugin extends Plugin {
@@ -51,19 +69,21 @@ export default class ArxivPaperPlugin extends Plugin {
             content: `<div class="b3-dialog__content siyuan-arxiv-dialog">
     <label class="siyuan-arxiv-dialog__label">${this.i18n.inputLabel}</label>
     <input class="b3-text-field fn__block siyuan-arxiv-dialog__input" placeholder="${this.i18n.inputPlaceholder}" />
+    <label class="siyuan-arxiv-dialog__checkbox"><input type="checkbox" class="b3-switch siyuan-arxiv-dialog__parse" />${this.i18n.parseFullTextLabel}</label>
     <div class="siyuan-arxiv-dialog__status" aria-live="polite"></div>
 </div>
 <div class="b3-dialog__action">
     <button class="b3-button b3-button--cancel">${this.i18n.cancel}</button><div class="fn__space"></div>
     <button class="b3-button b3-button--text siyuan-arxiv-dialog__confirm">${this.i18n.confirm}</button>
 </div>`,
-            width: this.isMobile ? "92vw" : "480px",
+            width: this.isMobile ? "92vw" : "520px",
         });
 
         const input = dialog.element.querySelector(".siyuan-arxiv-dialog__input") as HTMLInputElement;
         const cancelButton = dialog.element.querySelector(".b3-button--cancel") as HTMLButtonElement;
         const confirmButton = dialog.element.querySelector(".siyuan-arxiv-dialog__confirm") as HTMLButtonElement;
         const statusElement = dialog.element.querySelector(".siyuan-arxiv-dialog__status") as HTMLElement;
+        const parseCheckbox = dialog.element.querySelector(".siyuan-arxiv-dialog__parse") as HTMLInputElement;
 
         cancelButton.addEventListener("click", () => {
             dialog.destroy();
@@ -75,7 +95,7 @@ export default class ArxivPaperPlugin extends Plugin {
                 statusElement.classList.add("siyuan-arxiv-dialog__status--error");
                 return;
             }
-            await this.handleInsert(protyle, input.value.trim(), statusElement, confirmButton, dialog);
+            await this.handleInsert(protyle, input.value.trim(), parseCheckbox.checked, statusElement, confirmButton, dialog);
         };
 
         confirmButton.addEventListener("click", () => {
@@ -98,7 +118,7 @@ export default class ArxivPaperPlugin extends Plugin {
         }, 50);
     }
 
-    private async handleInsert(protyle: Protyle, rawInput: string, statusElement: HTMLElement, confirmButton: HTMLButtonElement, dialog: Dialog) {
+    private async handleInsert(protyle: Protyle, rawInput: string, parseFullText: boolean, statusElement: HTMLElement, confirmButton: HTMLButtonElement, dialog: Dialog) {
         statusElement.classList.remove("siyuan-arxiv-dialog__status--error");
         const arxivId = this.extractArxivId(rawInput);
         if (!arxivId) {
@@ -112,9 +132,19 @@ export default class ArxivPaperPlugin extends Plugin {
 
         try {
             statusElement.textContent = this.i18n.statusFetching;
-            const {title, pdfUrl} = await this.fetchArxivMetadata(arxivId);
+            const metadata = await this.fetchArxivMetadata(arxivId);
 
-            const fileName = this.buildPdfFileName(title, arxivId);
+            if (parseFullText) {
+                const markdown = await this.generateFullTextMarkdown(metadata, statusElement);
+                dialog.destroy();
+                protyle.focus();
+                const contentToInsert = markdown.endsWith("\n") ? markdown : `${markdown}\n`;
+                protyle.insert(contentToInsert, false, true);
+                showMessage(this.i18n.successParsedMessage.replace("${title}", metadata.title));
+                return;
+            }
+
+            const fileName = this.buildPdfFileName(metadata.title, metadata.versionedId);
             statusElement.textContent = this.i18n.statusCheckingExisting;
             const existingAssetPath = await this.findExistingAsset(fileName);
 
@@ -127,7 +157,7 @@ export default class ArxivPaperPlugin extends Plugin {
                 statusElement.textContent = this.i18n.statusReusingExisting;
             } else {
                 statusElement.textContent = this.i18n.statusDownloading;
-                const pdfBlob = await this.downloadPdf(pdfUrl);
+                const pdfBlob = await this.downloadPdf(metadata.pdfUrl);
 
                 statusElement.textContent = this.i18n.statusUploading;
                 assetPath = await this.uploadPdf(pdfBlob, fileName);
@@ -138,7 +168,7 @@ export default class ArxivPaperPlugin extends Plugin {
             protyle.focus();
             protyle.insert(markdownLink, false, true);
             const successTemplate = reusedExisting ? this.i18n.successReusedMessage : this.i18n.successMessage;
-            showMessage(successTemplate.replace("${title}", title));
+            showMessage(successTemplate.replace("${title}", metadata.title));
         } catch (error) {
             console.error(error);
             const message = error instanceof Error ? error.message : String(error);
@@ -180,7 +210,7 @@ export default class ArxivPaperPlugin extends Plugin {
             return candidate;
         }
 
-        const urlPattern = /arxiv\.org\/(?:abs|pdf)\/([^?#]+?)(?:\.pdf)?(?:[?#].*)?$/i;
+        const urlPattern = /arxiv.\org\/(?:abs|pdf)\/([^?#]+?)(?:\.pdf)?(?:[?#].*)?$/i;
         const match = trimmed.match(urlPattern);
         if (match) {
             const id = match[1].replace(/\.pdf$/i, "");
@@ -196,7 +226,7 @@ export default class ArxivPaperPlugin extends Plugin {
         return null;
     }
 
-    private async fetchArxivMetadata(arxivId: string): Promise<{title: string; pdfUrl: string}> {
+    private async fetchArxivMetadata(arxivId: string): Promise<ArxivMetadata> {
         const response = await fetch(`https://export.arxiv.org/api/query?id_list=${encodeURIComponent(arxivId)}`);
         if (!response.ok) {
             throw new Error(this.i18n.errorFetchMetadata);
@@ -216,8 +246,34 @@ export default class ArxivPaperPlugin extends Plugin {
         if (!title) {
             throw new Error(this.i18n.errorMissingTitle);
         }
-        const pdfUrl = `https://arxiv.org/pdf/${arxivId}.pdf`;
-        return {title, pdfUrl};
+
+        const idElement = entry.querySelector("id");
+        let canonicalId = arxivId;
+        if (idElement?.textContent) {
+            const extracted = idElement.textContent.trim().split("/").pop();
+            if (extracted) {
+                canonicalId = extracted;
+            }
+        }
+        let versionedId = canonicalId;
+        if (!/v\d+$/i.test(versionedId)) {
+            const versionLink = entry.querySelector('link[title="pdf"]')?.getAttribute("href")
+                ?? entry.querySelector('link[type="application/pdf"]')?.getAttribute("href");
+            if (versionLink) {
+                const lastSegment = versionLink.split("/").pop();
+                if (lastSegment) {
+                    versionedId = lastSegment.replace(/\.pdf$/i, "");
+                }
+            }
+        }
+        const pdfUrl = `https://arxiv.org/pdf/${encodeURIComponent(versionedId)}.pdf`;
+        const authorElements = Array.from(entry.querySelectorAll("author > name"));
+        const authors = authorElements
+            .map((element) => element.textContent?.replace(/\s+/g, " ").trim())
+            .filter((value): value is string => Boolean(value));
+        const summary = entry.querySelector("summary")?.textContent?.replace(/\s+/g, " ").trim();
+
+        return {title, pdfUrl, canonicalId, versionedId, authors, summary};
     }
 
     private async downloadPdf(url: string): Promise<Blob> {
@@ -301,5 +357,373 @@ export default class ArxivPaperPlugin extends Plugin {
             console.warn("Failed to check existing arXiv asset", err);
         }
         return null;
+    }
+
+    private async generateFullTextMarkdown(metadata: ArxivMetadata, statusElement: HTMLElement): Promise<string> {
+        statusElement.textContent = this.i18n.statusFetchingHtml;
+        let htmlContent: string | null = null;
+        try {
+            htmlContent = await this.fetchArxivHtml(metadata.versionedId);
+        } catch (err) {
+            console.warn("Failed to fetch arXiv HTML rendering", err);
+        }
+
+        if (htmlContent) {
+            statusElement.textContent = this.i18n.statusConvertingHtml;
+            const markdown = this.convertArxivHtmlToMarkdown(htmlContent, metadata);
+            if (markdown) {
+                return markdown;
+            }
+        }
+
+        statusElement.textContent = this.i18n.statusFallbackLatex;
+        const latexMarkdown = await this.fetchLatexMarkdown(metadata);
+        if (latexMarkdown) {
+            return latexMarkdown;
+        }
+
+        throw new Error(this.i18n.errorParseFullTextFailed);
+    }
+
+    private async fetchArxivHtml(versionedId: string): Promise<string | null> {
+        const url = `https://arxiv.org/html/${encodeURIComponent(versionedId)}`;
+        const response = await fetch(url, {headers: {Accept: "text/html"}});
+        if (!response.ok) {
+            if (response.status === 404) {
+                return null;
+            }
+            throw new Error(this.i18n.errorFetchHtml);
+        }
+        const text = await response.text();
+        if (!text.trim()) {
+            return null;
+        }
+        return text;
+    }
+
+    private convertArxivHtmlToMarkdown(htmlContent: string, metadata: ArxivMetadata): string | null {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(htmlContent, "text/html");
+        const article = doc.querySelector("article.ltx_document");
+        if (!article) {
+            return null;
+        }
+
+        this.ensureAbsoluteLinks(article, `https://arxiv.org/html/${metadata.versionedId}`);
+        this.unwrapMathElements(article);
+
+        const compressionBlocks = this.extractCompressionBlocks(article);
+
+        const turndown = new TurndownService({
+            headingStyle: "atx",
+            codeBlockStyle: "fenced",
+            hr: "---",
+        });
+
+        let markdown = turndown.turndown(article.innerHTML);
+        markdown = this.cleanupMarkdown(markdown);
+
+        const combinedBlocks: string[] = [];
+        if (compressionBlocks.meta) {
+            combinedBlocks.push(this.formatCodeBlock([compressionBlocks.meta]));
+        } else if (metadata.authors.length) {
+            combinedBlocks.push(this.formatCodeBlock([`${this.i18n.labelAuthors}: ${metadata.authors.join(", ")}`]));
+        }
+        if (compressionBlocks.references) {
+            combinedBlocks.push(this.formatCodeBlock([`${this.i18n.labelReferences}:`, compressionBlocks.references]));
+        }
+        if (compressionBlocks.acknowledgements) {
+            combinedBlocks.push(this.formatCodeBlock([`${this.i18n.labelAcknowledgements}:`, compressionBlocks.acknowledgements]));
+        }
+
+        if (combinedBlocks.length) {
+            markdown = `${combinedBlocks.join("\n\n")}` + "\n\n" + markdown;
+        }
+
+        return markdown.trim();
+    }
+
+    private ensureAbsoluteLinks(root: Element, baseUrl: string) {
+        const resolveUrl = (value: string | null): string | null => {
+            if (!value) {
+                return null;
+            }
+            try {
+                return new URL(value, baseUrl).href;
+            } catch (err) {
+                return value;
+            }
+        };
+
+        root.querySelectorAll("img").forEach((img) => {
+            const src = resolveUrl(img.getAttribute("src"));
+            if (src) {
+                img.setAttribute("src", src);
+            }
+        });
+
+        root.querySelectorAll("a").forEach((anchor) => {
+            const href = anchor.getAttribute("href");
+            if (!href || href.startsWith("#")) {
+                return;
+            }
+            const resolved = resolveUrl(href);
+            if (resolved) {
+                anchor.setAttribute("href", resolved);
+            }
+        });
+    }
+
+    private unwrapMathElements(root: Element) {
+        root.querySelectorAll("math").forEach((mathElement) => {
+            const tex = mathElement.getAttribute("alttext")?.trim();
+            if (!tex) {
+                return;
+            }
+            const display = mathElement.getAttribute("display") === "block";
+            const wrapper = mathElement.ownerDocument?.createElement("span");
+            if (!wrapper) {
+                return;
+            }
+            wrapper.textContent = display ? `\n\n$$\n${tex}\n$$\n\n` : ` $${tex}$ `;
+            mathElement.replaceWith(wrapper);
+        });
+    }
+
+    private extractCompressionBlocks(article: Element): {
+        meta?: string;
+        references?: string;
+        acknowledgements?: string;
+    } {
+        const sections: string[] = [];
+        const authorsElement = article.querySelector(".ltx_authors");
+        if (authorsElement) {
+            const text = this.normalizeWhitespace(authorsElement.textContent ?? "");
+            if (text) {
+                sections.push(`${this.i18n.labelAuthors}: ${text}`);
+            }
+            authorsElement.remove();
+        }
+
+        const metaText = sections.length ? sections.join("\n\n") : undefined;
+
+        const referencesText = this.extractSectionByHeading(article, ["references", "bibliography"], true);
+        const acknowledgementsText = this.extractSectionByHeading(article, ["acknowledgements", "acknowledgments"], true);
+
+        return {
+            meta: metaText,
+            references: referencesText,
+            acknowledgements: acknowledgementsText,
+        };
+    }
+
+    private extractSectionByHeading(article: Element, titles: string[], remove: boolean): string | undefined {
+        const lowerTitles = titles.map((title) => title.toLowerCase());
+        const sections = Array.from(article.querySelectorAll("section"));
+        for (const section of sections) {
+            const heading = section.querySelector("h1, h2, h3, h4, h5, h6");
+            const headingText = heading?.textContent?.trim().toLowerCase();
+            if (headingText && lowerTitles.some((title) => headingText.includes(title))) {
+                const text = this.normalizeWhitespace(section.textContent ?? "");
+                if (remove) {
+                    section.remove();
+                }
+                return text;
+            }
+        }
+
+        const bibliography = article.querySelector(".ltx_bibliography");
+        if (bibliography) {
+            const text = this.normalizeWhitespace(bibliography.textContent ?? "");
+            if (remove) {
+                bibliography.remove();
+            }
+            return text;
+        }
+
+        return undefined;
+    }
+
+    private cleanupMarkdown(markdown: string): string {
+        return markdown
+            .replace(/[\r\t]/g, "")
+            .replace(/\n{3,}/g, "\n\n")
+            .trim();
+    }
+
+    private normalizeWhitespace(value: string): string {
+        return value
+            .replace(/[\u00A0\u1680\u2000-\u200A\u202F\u205F\u3000]/g, " ")
+            .replace(/\s+/g, " ")
+            .trim();
+    }
+
+    private async fetchLatexMarkdown(metadata: ArxivMetadata): Promise<string | null> {
+        try {
+            const archiveBuffer = await this.downloadLatexArchive(metadata);
+            if (!archiveBuffer) {
+                return null;
+            }
+            const markdown = await this.convertLatexArchiveToMarkdown(archiveBuffer, metadata);
+            return markdown;
+        } catch (err) {
+            console.warn("Failed to convert LaTeX archive", err);
+            return null;
+        }
+    }
+
+    private async downloadLatexArchive(metadata: ArxivMetadata): Promise<ArrayBuffer | null> {
+        const baseId = metadata.canonicalId.replace(/v\d+$/i, "");
+        const candidates = [
+            `https://arxiv.org/src/${encodeURIComponent(baseId)}`,
+            `https://arxiv.org/src/${encodeURIComponent(metadata.versionedId)}`,
+            `https://arxiv.org/e-print/${encodeURIComponent(metadata.versionedId)}`,
+        ];
+        for (const url of candidates) {
+            try {
+                const response = await fetch(url);
+                if (!response.ok) {
+                    continue;
+                }
+                const buffer = await response.arrayBuffer();
+                if (buffer.byteLength === 0) {
+                    continue;
+                }
+                return buffer;
+            } catch (err) {
+                console.warn("Failed to download archive", url, err);
+            }
+        }
+        return null;
+    }
+
+    private async convertLatexArchiveToMarkdown(buffer: ArrayBuffer, metadata: ArxivMetadata): Promise<string | null> {
+        let tarData: Uint8Array;
+        try {
+            tarData = gunzipSync(new Uint8Array(buffer));
+        } catch (err) {
+            console.warn("Failed to decompress gzip archive", err);
+            return null;
+        }
+
+        let entries: UntarEntry[];
+        try {
+            entries = (await untar(tarData.buffer)) as UntarEntry[];
+        } catch (err) {
+            console.warn("Failed to untar archive", err);
+            return null;
+        }
+
+        const decoder = new TextDecoder("utf-8", {fatal: false});
+        const texEntries = entries
+            .filter((entry) => typeof entry.name === "string" && entry.name.toLowerCase().endsWith(".tex"))
+            .map((entry) => ({
+                name: entry.name,
+                content: this.decodeArchiveText(entry.buffer, decoder),
+            }))
+            .filter((entry) => Boolean(entry.content));
+
+        if (!texEntries.length) {
+            return null;
+        }
+
+        const mainEntry = this.selectMainTexEntry(texEntries);
+        if (!mainEntry) {
+            return null;
+        }
+
+        const markdownBody = this.convertLatexToMarkdown(mainEntry.content);
+        if (!markdownBody) {
+            return null;
+        }
+
+        const authorLine = metadata.authors.length
+            ? `${this.formatCodeBlock([`${this.i18n.labelAuthors}: ${metadata.authors.join(", ")}`])}\n\n`
+            : "";
+        return `${authorLine}${markdownBody}`.trim();
+    }
+
+    private decodeArchiveText(buffer: ArrayBuffer | undefined, decoder: TextDecoder): string {
+        if (!buffer) {
+            return "";
+        }
+        try {
+            return decoder.decode(new Uint8Array(buffer));
+        } catch (err) {
+            console.warn("Failed to decode archive entry", err);
+            return "";
+        }
+    }
+
+    private selectMainTexEntry(texEntries: Array<{name: string; content: string}>): {name: string; content: string} | null {
+        const withDocument = texEntries.find((entry) => /\\begin\{document}/.test(entry.content));
+        if (withDocument) {
+            return withDocument;
+        }
+        return texEntries.sort((a, b) => b.content.length - a.content.length)[0] ?? null;
+    }
+
+    private convertLatexToMarkdown(content: string): string {
+        const documentMatch = content.match(/\\begin\{document}([\s\S]*?)\\end\{document}/);
+        const body = documentMatch ? documentMatch[1] : content;
+        let markdown = body;
+
+        markdown = markdown.replace(/%.*$/gm, "");
+        markdown = markdown.replace(/\\label\{[^}]*}/g, "");
+        markdown = markdown.replace(/\\cite\{[^}]*}/g, "");
+        markdown = markdown.replace(/\\ref\{([^}]*)}/g, "$1");
+        markdown = markdown.replace(/\\footnote\{([^}]*)}/g, " ($1) ");
+        markdown = markdown.replace(/\\textbf\{([^}]*)}/g, "**$1**");
+        markdown = markdown.replace(/\\textit\{([^}]*)}/g, "*$1*");
+        markdown = markdown.replace(/\\emph\{([^}]*)}/g, "*$1*");
+
+        markdown = markdown.replace(/\\begin\{itemize}([\s\S]*?)\\end\{itemize}/g, (_match, items) => this.convertLatexList(items, false));
+        markdown = markdown.replace(/\\begin\{enumerate}([\s\S]*?)\\end\{enumerate}/g, (_match, items) => this.convertLatexList(items, true));
+
+        markdown = markdown.replace(/\\section\*?\{([^}]*)}/g, (_match, title) => `\n## ${title.trim()}\n`);
+        markdown = markdown.replace(/\\subsection\*?\{([^}]*)}/g, (_match, title) => `\n### ${title.trim()}\n`);
+        markdown = markdown.replace(/\\subsubsection\*?\{([^}]*)}/g, (_match, title) => `\n#### ${title.trim()}\n`);
+
+        markdown = markdown.replace(/\\begin\{(equation|align|gather|multline)\*?}([\s\S]*?)\\end\{\1\*?}/g, (_match, _env, inner) => `\n\n$$\n${inner.trim()}\n$$\n\n`);
+        markdown = markdown.replace(/\\\[/g, "$$\n");
+        markdown = markdown.replace(/\\\]/g, "\n$$");
+        markdown = markdown.replace(/\\\(/g, "$\n");
+        markdown = markdown.replace(/\\\)/g, "\n$");
+
+        markdown = markdown.replace(/\\includegraphics(?:\[[^]]*])?\{([^}]*)}/g, (_match, file) => `![${this.i18n.labelFigurePlaceholder}](${file})`);
+
+        markdown = markdown.replace(/\\begin\{table}([\s\S]*?)\\end\{table}/g, (_match, inner) => `\n\n${inner.trim()}\n\n`);
+        markdown = markdown.replace(/\\begin\{figure}([\s\S]*?)\\end\{figure}/g, (_match, inner) => `\n\n${inner.trim()}\n\n`);
+
+        markdown = markdown.replace(/\\newline/g, "\n");
+        markdown = markdown.replace(/~+/g, " ");
+        markdown = markdown.replace(/\\(text|mathrm|mathit|mathbf)\s*\{([^}]*)}/g, "$2");
+        markdown = markdown.replace(/\\%/g, "%");
+        markdown = markdown.replace(/\\_/g, "_");
+        markdown = markdown.replace(/\\&/g, "&");
+        markdown = markdown.replace(/\\#/g, "#");
+        markdown = markdown.replace(/\\\$/g, "$");
+
+        markdown = markdown.replace(/\n{3,}/g, "\n\n");
+        markdown = markdown.replace(/[ \t]+\n/g, "\n");
+
+        return markdown.trim();
+    }
+
+    private convertLatexList(items: string, numbered: boolean): string {
+        const parts = items
+            .split(/\\item/g)
+            .map((part) => part.trim())
+            .filter(Boolean);
+        if (!parts.length) {
+            return "";
+        }
+        return `\n${parts
+            .map((part, index) => (numbered ? `${index + 1}. ${part}` : `- ${part}`))
+            .join("\n")}\n`;
+    }
+
+    private formatCodeBlock(lines: string[]): string {
+        return ["```text", ...lines, "```"].join("\n");
     }
 }


### PR DESCRIPTION
## Summary
- add a **Parse full text** checkbox to the insert dialog and route successful parses directly into the editor
- convert arXiv HTML renderings into Markdown (with metadata compression) and fall back to LaTeX source archives when HTML is unavailable
- refresh styling, localization, documentation, changelog, and bump the plugin version to 0.2.0

## Testing
- pnpm run build
- pnpm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68d7ea2d023483309b7f5518da742547