### PR TITLE
添加基于代理的浏览器前端PDF下载，以便 Docker 端也能正确下载使用（解决 CROS 错误）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.5 2025-09-28
+* 修复在Docker端部署SiYuan时，浏览器下载报CROS错误
+* Fix the issue where the browser reports a CORS error when deploying SiYuan on the Docker end.
+
 ## v0.1.0 2025-09-27
 
 * 实现在思源笔记中根据 arxiv 链接自动爬取 pdf 文件到本地资源目录

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Repository: https://github.com/Jasaxion/siyuan-arxiv-paper-download
 
 Having issues? --> https://github.com/Jasaxion/siyuan-arxiv-paper-download/issues
 
+## Changelog  
+
+- 2025-09-28: Fixed CORS cross-origin access errors caused by file downloads in SiYuan Notes under Docker  
+- 2025-09-27: Implemented downloading documents from Arxiv and inserting them into SiYuan Notes
+
 ## Features
 
 - Adds a `/` command named **Insert arXiv paper**.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Having issues? --> https://github.com/Jasaxion/siyuan-arxiv-paper-download/issue
 ## Features
 
 - Adds a `/` command named **Insert arXiv paper**.
-- Accepts `https://arxiv.org/abs/...`, `https://arxiv.org/pdf/...`, or raw identifiers such as `2509.17567`.
+- Accepts `https://arxiv.org/abs/...`, `https://arxiv.org/pdf/...`, or raw identifiers such as `2508.05592`.
 - Downloads the PDF, stores it in `assets/`, and inserts a Markdown link using the paper title as the filename.
 - Skips re-downloading when the titled PDF already exists in `assets/` and simply reuses it.
 - Can be used in conjunction with the additional plugin PaperLess to achieve global management of personal academic paper documents: [PaperLess](https://github.com/Jasaxion/siyuan-paperless)

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -8,10 +8,15 @@
 
 若遇到问题请前往：https://github.com/Jasaxion/siyuan-arxiv-paper-download/issues
 
+## 更新日志
+
+- 2025-09-28: 修复 Docker 下 SiYuan 笔记在下载文件时导致的 CROS 跨域访问错误
+- 2025-09-27: 实现从 Arxiv 下载文档并插入到 SiYuan笔记中
+
 ## 功能
 
 - 在输入 `/` 时新增 **插入 arXiv 论文** 菜单项。
-- 支持 `https://arxiv.org/abs/...`、`https://arxiv.org/pdf/...` 以及 `2509.17567` 等编号格式。
+- 支持 `https://arxiv.org/abs/...`、`https://arxiv.org/pdf/...` 以及 `2508.05592` 等编号格式。
 - 自动获取论文标题，下载 PDF 到 `assets/` 目录，并以标题命名。
 - 如果 `assets/` 中已存在同名 PDF，则直接复用，避免重复下载。
 - 在文档中插入 `[论文标题.pdf](assets/论文标题.pdf)` 格式的链接。

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "siyuan-arxiv-paper-download",
   "author": "Jasaxion(BaiBo)",
   "url": "https://github.com/Jasaxion/siyuan-arxiv-paper-download",
-  "version": "0.1.2",
+  "version": "0.1.5",
   "minAppVersion": "3.3.0",
   "backends": ["all"],
   "frontends": ["all"],

--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -17,5 +17,8 @@
   "errorNotFound": "The specified arXiv paper was not found.",
   "errorMissingTitle": "The paper title could not be determined.",
   "errorDownloadPdf": "Failed to download the PDF file.",
-  "errorUploadPdf": "Failed to upload the PDF to SiYuan."
+  "errorUploadPdf": "Failed to upload the PDF to SiYuan.",
+  "errorProxyRequest": "Failed to contact the proxy endpoint.",
+  "errorProxyStatus": "Proxy returned HTTP ${status}.",
+  "errorProxyEncoding": "Proxy response encoding ${encoding} is not supported."
 }

--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -20,5 +20,6 @@
   "errorUploadPdf": "Failed to upload the PDF to SiYuan.",
   "errorProxyRequest": "Failed to contact the proxy endpoint.",
   "errorProxyStatus": "Proxy returned HTTP ${status}.",
-  "errorProxyEncoding": "Proxy response encoding ${encoding} is not supported."
+  "errorProxyEncoding": "Proxy response encoding ${encoding} is not supported.",
+  "errorBrowserDirectFallback": "Direct browser download failed: ${detail}."
 }

--- a/src/i18n/zh_CN.json
+++ b/src/i18n/zh_CN.json
@@ -17,5 +17,8 @@
   "errorNotFound": "未找到对应的 arXiv 论文。",
   "errorMissingTitle": "无法获取论文标题。",
   "errorDownloadPdf": "下载 PDF 文件失败。",
-  "errorUploadPdf": "上传 PDF 到思源失败。"
+  "errorUploadPdf": "上传 PDF 到思源失败。",
+  "errorProxyRequest": "无法访问代理端点。",
+  "errorProxyStatus": "代理返回 HTTP ${status}。",
+  "errorProxyEncoding": "暂不支持代理响应编码 ${encoding}。"
 }

--- a/src/i18n/zh_CN.json
+++ b/src/i18n/zh_CN.json
@@ -20,5 +20,6 @@
   "errorUploadPdf": "上传 PDF 到思源失败。",
   "errorProxyRequest": "无法访问代理端点。",
   "errorProxyStatus": "代理返回 HTTP ${status}。",
-  "errorProxyEncoding": "暂不支持代理响应编码 ${encoding}。"
+  "errorProxyEncoding": "暂不支持代理响应编码 ${encoding}。",
+  "errorBrowserDirectFallback": "浏览器直接下载失败：${detail}。"
 }


### PR DESCRIPTION
- 通过SiYuan的转发代理路由基于浏览器的PDF下载，以避免CORS问题
- 在上传资源之前，将代理的base64有效载荷转换回Blobs，并在桌面重复使用直接下载的方式
